### PR TITLE
Feat/otp codes sent

### DIFF
--- a/server/toota/authentication/serializers.py
+++ b/server/toota/authentication/serializers.py
@@ -4,6 +4,9 @@ from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 from .models import User, OTP
 from .utils import generate_otp, send_otp_email
+from django.utils import timezone
+from datetime import timedelta
+
 
 class UserSignupSerializer(serializers.ModelSerializer):
     """

--- a/server/toota/toota/settings.py
+++ b/server/toota/toota/settings.py
@@ -9,7 +9,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config('SECRET_KEY')  # Load secret key from .env
 DEBUG = config('DEBUG', default=True, cast=bool)  # Default to True if not set
 
-ALLOWED_HOSTS = ['toota-mobile-sa.onrender.com']  # Add your domain to ALLOWED_HOSTS
+ALLOWED_HOSTS = ['toota-mobile-sa.onrender.com',
+                 '127.0.0.1'
+                ]  # Add your domain to ALLOWED_HOSTS
 
 AUTH_USER_MODEL = 'authentication.User'
 

--- a/server/toota/toota/urls.py
+++ b/server/toota/toota/urls.py
@@ -1,8 +1,12 @@
 from django.contrib import admin
-from django.urls import path, include, re_path  # <-- Add re_path here
+from django.urls import path, include, re_path
+from django.conf import settings
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
+
+# Define the base URL dynamically based on the environment
+swagger_url = "http://127.0.0.1:8000" if settings.DEBUG else "https://toota-mobile-sa.onrender.com"
 
 # Define the schema view for Swagger UI
 schema_view = get_schema_view(
@@ -19,8 +23,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),
-    # Define schemes at the schema level
-    url="https://toota-mobile-sa.onrender.com",  # Use your Render URL
+    url=swagger_url,  # Use the dynamic URL
 )
 
 urlpatterns = [
@@ -33,3 +36,4 @@ urlpatterns = [
     # path("payments/", include("payments.urls")),    # Payments-related endpoints
     # path("notifications/", include("notification.urls")),  # Notifications-related endpoints
 ]
+


### PR DESCRIPTION
This pull request includes several updates to improve the authentication and settings configuration, as well as to dynamically define the base URL for Swagger UI based on the environment.

### Improvements to authentication and settings configuration:

* [`server/toota/authentication/serializers.py`](diffhunk://#diff-12d6ed7927e9d0a78e89d60a9763a1f418c4dd5dd59dd3803518567f6645a169R7-R9): Added imports for `timezone` and `timedelta` to support time-based functionalities.
* [`server/toota/toota/settings.py`](diffhunk://#diff-60a762b82f1ba0b6eb8966ccffd1056e81fbbab54d41648fc57db5199cc82b5bL12-R14): Updated `ALLOWED_HOSTS` to include `127.0.0.1` for local development.

### Dynamic URL configuration for Swagger UI:

* [`server/toota/toota/urls.py`](diffhunk://#diff-ef233e721457d8e9efe130e8c30eac1a8d6a63d07e5ee8d531781ab0dec05909L2-R10): Defined the base URL dynamically based on the environment (`DEBUG` setting) and updated the schema view to use this dynamic URL. [[1]](diffhunk://#diff-ef233e721457d8e9efe130e8c30eac1a8d6a63d07e5ee8d531781ab0dec05909L2-R10) [[2]](diffhunk://#diff-ef233e721457d8e9efe130e8c30eac1a8d6a63d07e5ee8d531781ab0dec05909L22-R26)
* [`server/toota/toota/urls.py`](diffhunk://#diff-ef233e721457d8e9efe130e8c30eac1a8d6a63d07e5ee8d531781ab0dec05909R39): Removed unnecessary comments and added a blank line for better readability.