### PR TITLE
solved the error on password reset

### DIFF
--- a/server/toota/toota/urls.py
+++ b/server/toota/toota/urls.py
@@ -5,7 +5,7 @@ from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
 # Use the production URL as the default for Swagger
-swagger_url = "https://toota-mobile-sa.onrender.com"
+swagger_url = "http://127.0.0.1:8000/"
 
 # Define the schema view for Swagger UI
 schema_view = get_schema_view(


### PR DESCRIPTION
This pull request includes several changes to the password reset functionality and the Swagger URL configuration. The most important changes include refactoring the password reset logic, updating permission classes, and modifying the Swagger URL for local development.

Improvements to password reset functionality:

* [`server/toota/authentication/views.py`](diffhunk://#diff-15df44b5a949f3748f48ef2344e3d96f6ee96a50722f3c5043048f1978fff6bcL127-R152): Refactored the `BaseResetPasswordView` class to simplify the password reset logic by directly handling OTP validation and password reset within the `post` method. Removed the use of serializers and added explicit handling of OTP expiration and user not found scenarios.

Permission class updates:

* [`server/toota/authentication/views.py`](diffhunk://#diff-15df44b5a949f3748f48ef2344e3d96f6ee96a50722f3c5043048f1978fff6bcR212): Added `permission_classes = []` to both `UserResetPasswordView` and `DriverResetPasswordView` to allow unauthenticated access for password reset requests. [[1]](diffhunk://#diff-15df44b5a949f3748f48ef2344e3d96f6ee96a50722f3c5043048f1978fff6bcR212) [[2]](diffhunk://#diff-15df44b5a949f3748f48ef2344e3d96f6ee96a50722f3c5043048f1978fff6bcR332-R333)

Swagger URL configuration:

* [`server/toota/toota/urls.py`](diffhunk://#diff-ef233e721457d8e9efe130e8c30eac1a8d6a63d07e5ee8d531781ab0dec05909L8-R8): Changed the `swagger_url` from the production URL to the local development URL (`http://127.0.0.1:8000/`).